### PR TITLE
Add DEFAULT_ROOT_FOLDER to settings

### DIFF
--- a/cloud/file_upload.py
+++ b/cloud/file_upload.py
@@ -34,6 +34,7 @@ class ProgressPercentage(object):
 
 
 class FileUploaderClass:
+
     def create_file_uploader(self, provider: str) -> None:
         if provider == "AWS":
             return S3FileUploader()
@@ -46,6 +47,7 @@ class FileUploaderClass:
 
 
 class FileUploader:
+
     def upload_file(self, file_path: str):
         pass
 
@@ -58,6 +60,7 @@ class S3FileUploader(FileUploader):
         self.bucket_name = AwsConfig.AWS_BUCKET_NAME
         self.region = AwsConfig.AWS_DEFAULT_REGION
         self.endpoint_url = AwsConfig.AWS_ENDPOINT_URL
+        self.root_folder = AwsConfig.DEFAULT_ROOT_FOLDER
 
     def upload_file(self, file_path: str, key_path: str, region: str=None) -> int:
 
@@ -121,12 +124,16 @@ class S3FileUploader(FileUploader):
         return result
 
 class GoogleCloudFileUploader(FileUploader):
+
     def __init__(self):
         self.bucket_name = GoogleConfig.GGL_BUCKET_NAME
         self.credentials_path = GoogleConfig.GGL_CREDENTIALS_PATH
+        self.root_folder = GoogleConfig.DEFAULT_ROOT_FOLDER
 
     def upload_file(self, file_path: str, key_path: str) -> int:
+
         logger.info(f"Uploading {file_path} to Google Cloud Storage")
+        
         try:
             storage_client = storage.Client.from_service_account_json(self.credentials_path)
             bucket = storage_client.get_bucket(self.bucket_name)
@@ -160,6 +167,7 @@ class GoogleCloudFileUploader(FileUploader):
 
 
 class AzureFileUploader(FileUploader):
+
     def upload_file(self, file_path: str) -> int:
         # Upload file to Azure
         pass

--- a/nifty.py
+++ b/nifty.py
@@ -37,8 +37,9 @@ if __name__ == '__main__':
     # File upload and get shareable link
     uploader_factory = FileUploaderClass()
     uploader = uploader_factory.create_file_uploader(args.provider)
-    uploader.upload_file(args.file_path, f"testfolder/{os.path.basename(args.file_path)}")
-    link = uploader.get_shareable_link(f"testfolder/{os.path.basename(args.file_path)}")
+    logger.debug(f"Target Storage Subfolder: {uploader.root_folder}")
+    uploader.upload_file(args.file_path, f"{uploader.root_folder}/{os.path.basename(args.file_path)}")
+    link = uploader.get_shareable_link(f"{uploader.root_folder}/{os.path.basename(args.file_path)}")
     logger.debug(f"Shareable link: {link}")
 
     expiry_date = datetime.now() + timedelta(days=7)

--- a/settings_example.py
+++ b/settings_example.py
@@ -2,6 +2,8 @@
 
 class AwsConfig:
 
+    DEFAULT_ROOT_FOLDER = 'testfolder'
+
     AWS_ACCESS_KEY = ""
     AWS_SECRET_ACCESS_KEY = ""
     AWS_BUCKET_NAME = ""
@@ -16,6 +18,8 @@ class AwsConfig:
 
 
 class GoogleConfig:
+
+    DEFAULT_ROOT_FOLDER = 'testfolder'
 
     GGL_BUCKET_NAME = 'nifty-storage'
     GGL_CREDENTIALS_PATH = 'google.json'


### PR DESCRIPTION
Allow the user to set their own default path in settings.py so we can call an attribute `uploader.root_folder` rather than a hardcoded string `"testfolder"` in the __main__ program:

Change this:
```python
    uploader.upload_file(args.file_path, f"testfolder/{os.path.basename(args.file_path)}")
    link = uploader.get_shareable_link(f"testfolder/{os.path.basename(args.file_path)}")
```

To this:
```python
    uploader.upload_file(args.file_path, f"{uploader.root_folder}/{os.path.basename(args.file_path)}")
    link = uploader.get_shareable_link(f"{uploader.root_folder}/{os.path.basename(args.file_path)}")
```